### PR TITLE
feat: 15 add eventbrite url in social section of the footer

### DIFF
--- a/src/config/site.js
+++ b/src/config/site.js
@@ -10,6 +10,7 @@ const siteConfig = {
     Twitch: "https://twitch.tv/surabayajs",
     Twitter: "https://twitter.com/surabaya_js",
     Youtube: "https://www.youtube.com/channel/UCHkB77QEg1w-1E9bmsGKDYg",
+    Eventbrite: "https://www.eventbrite.com/o/surabayajs-19948370921",
   },
   themeColor: "#96D2AF",
 };


### PR DESCRIPTION
closed #15 

add eventbrite url in social section of the footer, so visitor can easily register to any meetup that are hosted in eventbrite

preview:
![https://cdn.discordapp.com/attachments/750304684836651039/1084436306169442314/Capture-2023-03-12-181155.png](https://cdn.discordapp.com/attachments/750304684836651039/1084436306169442314/Capture-2023-03-12-181155.png)

dear mas @nusendra @grikomsn @joshuanatanielnm, will be happy if any of you can review this PR. 
thanks!